### PR TITLE
Fixed missing data key in relationships

### DIFF
--- a/drf_jsonapi/mixins.py
+++ b/drf_jsonapi/mixins.py
@@ -233,21 +233,20 @@ class RelationshipListMixin(object):
         if related is None:
             related = handler.get_related(resource)
 
-        # Sorting
-        if handler.many:
-            related = self.serializer_class.sort(request.GET.get('sort'), related)
+        if related:
+            # Sorting
+            if handler.many:
+                related = self.serializer_class.sort(request.GET.get('sort'), related)
+                related = self.apply_pagination(related)
 
-        # Paging
-        if handler.many:
-            related = self.apply_pagination(related)
+            serializer = resource_identifier(serializer_class)(
+                related,
+                many=handler.many
+            )
 
-        serializer = resource_identifier(serializer_class)(
-            related,
-            many=handler.many
-        )
-
-        self.document.instance.data = serializer.data
-        self.document.instance.included = serializer.included
+            self.document.instance.data = serializer.data
+        else:
+            self.document.instance.data = [] if handler.many else None
 
         return Response(self.document.data)
 

--- a/drf_jsonapi/serializers/resources.py
+++ b/drf_jsonapi/serializers/resources.py
@@ -95,6 +95,9 @@ class ResourceSerializer(serializers.Serializer):
         for field_name in existing - allowed:
             self.fields.pop(field_name)
 
+    def get_initial(self):
+        return {}
+
     def run_validation(self, data):
         """
         Validates the resource object according to JSON API spec.
@@ -125,7 +128,6 @@ class ResourceSerializer(serializers.Serializer):
         :return: A dictionary representing a JSON-API resource object
         :rtype: dict
         """
-
         resource = {
             'type': self.Meta.type,
             'id': self.get_id(instance)
@@ -211,7 +213,7 @@ class ResourceSerializer(serializers.Serializer):
         serializer_class = handler.get_serializer_class()
         related = handler.get_related(instance)
 
-        if related is not None:
+        if related:
             if handler.many:
                 related, data['meta'] = handler.apply_pagination(related, self.page_size)
 
@@ -225,6 +227,8 @@ class ResourceSerializer(serializers.Serializer):
                 many=handler.many,
                 only_fields=self.only_fields
             ).data)
+        else:
+            data['data'] = [] if handler.many else None
 
         return data
 


### PR DESCRIPTION
Hey guys I had to make a couple more changes to this because there were still issues.
- If a resource did not have an optional related resource the `data` key was just missing. This could cause issues if the user expects the key to exist (sometimes its there, sometimes it's not). `data` should always be there and if there is not relationship the value should be `null` (to one) or `[]` (to many). You should be able to copy the resource object and paste it into a PATCH request and it work.
- the `foo/{id}/relationships/bar` endpoint still showed the empty default object rather than `null` or `[]`. It turns out if you pass `None` to a serializer and then try to access `.data` it skips the call to `serializer.to_representation()` and calls `serializer.get_initial()`. The default implementation is just an empty model. That's why we were getting that odd result originally. I just implemented a simple `get_initial()` that returns an empty dict. (I would have liked to return None but that caused issues since DRF is expecting an iterable)