### PR TITLE
Render included section as list

### DIFF
--- a/drf_jsonapi/serializers/resources.py
+++ b/drf_jsonapi/serializers/resources.py
@@ -31,7 +31,7 @@ class ResourceListSerializer(serializers.ListSerializer):
         :rtype: dict_values
         """
 
-        return {(x['type'], x['id']): x for x in self.child.included}.values()
+        return list({(x['type'], x['id']): x for x in self.child.included}.values())
 
 
 class ResourceSerializer(serializers.Serializer):


### PR DESCRIPTION
Fixes an issue encountered during unit testing in which the data representing the `included` section of the response payload was rendered as a `dict_view` instead of a `list`. The former is not iterable or subscriptable (ie: difficult to manipulate for testing).