### PR TITLE
Issue #19: Filter params that span relationships have incorrect format

### DIFF
--- a/drf_jsonapi/filters.py
+++ b/drf_jsonapi/filters.py
@@ -7,7 +7,7 @@ from django_filters.filters import Filter
 from .objects import Error
 
 
-FILTER_PATTERN = re.compile("^filter\[([\w_-]+)\]\[?([\w_-]+)?\]?$")
+FILTER_PATTERN = re.compile("^filter\[([\w\._-]+)\]\[?([\w_-]+)?\]?$")
 
 
 class FilterParseError(Exception):


### PR DESCRIPTION
Very simple regex change. The previous pattern did not match periods (.) so the parsing was simply skipped for those.

This fixes this issue: https://github.com/Vacasa/drf-jsonapi/issues/19