### PR TITLE
Fixes issue #20

### DIFF
--- a/drf_jsonapi/serializers/resources.py
+++ b/drf_jsonapi/serializers/resources.py
@@ -435,7 +435,7 @@ class ResourceModelSerializer(ResourceSerializer, serializers.ModelSerializer):
         sort_fields = list(filter(None, sort_param.split(',')))
 
         # validate the sort fields actually exist in the model
-        field_names = [field.name for field in queryset.model._meta.get_fields()]
+        field_names = getattr(cls.Meta, 'sort_fields', cls.Meta.fields)
         test_fields = [field[1:] if field[0] in ('-', '+') else field for field in sort_fields]
         invalid_fields = set(test_fields).difference(field_names)
 


### PR DESCRIPTION
Previously we were introspecting models to get valid fields to sort by. The problem is that fields that span relationships aren't included so any field that spanned relationships would fail validation. This change gets rid of the introspection and simply checks the serializer's `Meta.sort_fields` or falls back to `Meta.fields` if not set.

This solves the validation issue and pushes the responsibility to Serializer authors to specify valid sort fields.

This fixes this issue: https://github.com/Vacasa/drf-jsonapi/issues/20