### PR TITLE
Fixes bug #33

### DIFF
--- a/drf_jsonapi/backends.py
+++ b/drf_jsonapi/backends.py
@@ -1,11 +1,8 @@
 from django_filters.rest_framework.backends import DjangoFilterBackend as BaseClass
 from django_filters import compat
+from django.db.models import Field
 
-try:
-    from django_filters.filters import LOOKUP_TYPES
-except ImportError:
-    from django.db.models import Field
-    LOOKUP_TYPES = Field.get_lookups().keys()
+LOOKUP_TYPES = Field.get_lookups().keys()
 
 
 class DjangoFilterBackend(BaseClass):

--- a/drf_jsonapi/backends.py
+++ b/drf_jsonapi/backends.py
@@ -1,6 +1,11 @@
 from django_filters.rest_framework.backends import DjangoFilterBackend as BaseClass
-from django_filters.filters import LOOKUP_TYPES
 from django_filters import compat
+
+try:
+    from django_filters.filters import LOOKUP_TYPES
+except ImportError:
+    from django.db.models import Field
+    LOOKUP_TYPES = Field.get_lookups().keys()
 
 
 class DjangoFilterBackend(BaseClass):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,9 +3,8 @@ chardet==3.0.4
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.5.1
-Django==2.0.6
-django-filter==1.1.0
-django-filters==0.2.1
+Django==2.1.2
+django-filter==2.0.0
 djangorestframework==3.8.2
 drf-yasg==1.8.0
 future==0.16.0


### PR DESCRIPTION
This PR fixes #33 by using the proper Django API for getting lookup types. `django-filter` was relying on a private constant called QUERY_TYPES to populate it's LOOKUP_TYPES constant. QUERY_TYPES was recently removed which broken any code that depended on it.

The fix was to use the proper public API to get all lookup types which could include custom lookups as well.