### PR TITLE
Get package version from Git tags

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/drf_jsonapi/__init__.py
+++ b/drf_jsonapi/__init__.py
@@ -1,0 +1,6 @@
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 setup(
     name='drf-jsonapi',
-    version='0.1.0',
+    use_scm_version=True,
     license='MIT',
     description='OpenSource Django JSONAPI Library',
     long_description=readme(),
@@ -24,5 +24,6 @@ setup(
         'django-filter',
         'drf-yasg',
     ],
+    setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
     zip_safe=False
 )


### PR DESCRIPTION
# What
Auto-set package version based on Git tags via [setupstools_scm](https://github.com/pypa/setuptools_scm/). This means all we have to do is `git tag 1.2.3` or the like and the version bits are set automagically when the code is installed via `pip` or some such tool.

# Test
- [ ] In an empty directory, run `pipenv install https://github.com/Vacasa/drf-jsonapi/archive/0.5.1.tar.gz`
-  [ ] `pipenv shell`, then `import drf_jsonapi` and `drf_jsonapi.__version__` should output `'0.5.1'`, indicating the version has been determined automatically from the Git tag.