### PR TITLE
Bug/53 Fix resource save for models with multiple To-One relationships

### DIFF
--- a/drf_jsonapi/mixins.py
+++ b/drf_jsonapi/mixins.py
@@ -417,6 +417,8 @@ class RelationshipPatchMixin(object):
             )
             handler.set_related(resource, related)
 
+        resource.save()
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/drf_jsonapi/relationships.py
+++ b/drf_jsonapi/relationships.py
@@ -195,7 +195,6 @@ class RelationshipHandler(object):
             getattr(resource, self.related_field).set(related)
         else:
             setattr(resource, self.related_field, related)
-            resource.save()
 
     def remove_related(self, resource, related, request=None):
         """


### PR DESCRIPTION
Fixes #53.

The previous PR on this issue introduced a problem where saving models with multiple required To-One relationships was blocked because the code was trying to `set_related` on one of the To-Ones, _then save_ the resource before setting the _other_ related resources properly.