### PR TITLE
Bug/74 Automatically convert id values to strings during serialization (for support/0.x branch)

### DIFF
--- a/drf_jsonapi/serializers/resources.py
+++ b/drf_jsonapi/serializers/resources.py
@@ -259,7 +259,8 @@ class ResourceSerializer(serializers.Serializer):
         """
 
         attr = getattr(self.Meta, 'id_field', 'pk')
-        return getattr(instance, attr)
+        id_value = getattr(instance, attr)
+        return str(id_value)
 
     def get_meta(self, instance):
         """

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -361,6 +361,7 @@ class ResourceSerializerTestCase(TestCase):
     def test_get_id(self):
         serializer = mocks.TestResourceSerializer(self.resource)
         self.assertEqual(serializer.get_id(serializer.instance), self.resource.pk)
+        self.assertIsInstance(serializer.get_id(serializer.instance), str)
 
     def test_get_object_by_id(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Fixes #74 for the `support/0.x` branch