### PR TITLE
Bug/74 Automatically convert id values to strings during serialization

### DIFF
--- a/drf_jsonapi/serializers/resources.py
+++ b/drf_jsonapi/serializers/resources.py
@@ -304,7 +304,8 @@ class ResourceSerializer(serializers.Serializer):
         :return: A primary key string
         :rtype: string
         """
-        return getattr(instance, self.get_id_field())
+        id_value = getattr(instance, self.get_id_field())
+        return str(id_value)
 
     def get_meta(self, _instance):
         """

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -424,6 +424,7 @@ class ResourceSerializerTestCase(TestCase):
     def test_get_id(self):
         serializer = mocks.TestResourceSerializer(self.resource)
         self.assertEqual(serializer.get_id(serializer.instance), self.resource.pk)
+        self.assertIsInstance(serializer.get_id(serializer.instance), str)
 
     def test_get_object_by_id(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Fixes #74 (for `master`)