### PR TITLE
ISSUE-77 HOTFIX Save the resource after processing relationships

### DIFF
--- a/drf_jsonapi/mixins.py
+++ b/drf_jsonapi/mixins.py
@@ -189,13 +189,13 @@ class PartialUpdateMixin(ProcessRelationshipsMixin):
         if not serializer.is_valid():
             return self.error_response(Error.parse_validation_errors(serializer.errors))
 
-        resource = serializer.save()
-
         # Check for relationships and process them
         if "relationships" in request.data["data"]:
             self.process_relationships(
                 request.data["data"]["relationships"], resource, request
             )
+
+        serializer.save()
 
         self.document.instance.data = serializer.data
 


### PR DESCRIPTION
Fixes issue #77 while preserving changes to fk relationships

**Test**
1. Using a resource with a many-to-many relationship make a single PATCH request to an existing record. The body should update resource attributes and create/change linkages in the resources m2m relationship. Validate the following:
    - `django.db.models.Model.save()` is only called once (there should only be one DB `UPDATE` statement)
    - All resource attributes from the request have been updated appropriately and committed to the DB
    - The linkages in the m2m relationship should be changed appropriately and committed to the DB

1. Repeat step one but this time with a resource that has a "to-one" relationship. The relationship many be "one-to-many" or "one-to-one" as both of these relationship types are set the same way in Django (attribute assignment). Validate the following:
    - `django.db.models.Model.save()` is only called once (there should only be one DB `UPDATE` statement)
    - All resource attributes from the request have been updated appropriately and committed to the DB
    - The linked "to-one" resource should be assigned appropriately and committed to the DB