### PR TITLE
Fixes saving of resource on singular relationship update

### DIFF
--- a/drf_jsonapi/mixins.py
+++ b/drf_jsonapi/mixins.py
@@ -292,6 +292,9 @@ class RelationshipUpdateMixin:
 
         handler.set_related(resource, related, request)
 
+        if not handler.many:
+            resource.save()
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 


### PR DESCRIPTION
When `PATCH`ing a singular relationship, the resource is not correctly saved. This PR fixes this issue.