### PR TITLE
UNIT-620: Fix sparse fieldsets for missing include objects

### DIFF
--- a/tests/nested_includes/tests.py
+++ b/tests/nested_includes/tests.py
@@ -36,3 +36,12 @@ class NestedIncludesTestCase(TestCase):
     def test_invalid_include(self):
         response = self.client.get("/leaves?include=foo.bar")
         self.assertEqual(response.status_code, 400)
+
+    def test_nested_sparse_fieldsets_no_members(self):
+        trunk = Trunk.objects.create(name="No relationships")
+        response = self.client.get(
+            "/trunks/{}?include=branches.leaves&fields[branch]=name&fields[leaf]=name".format(
+                trunk.pk
+            )
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
- Fixes a bug where ParseError was thrown when asking for sparse fields on include objects where the requested resource had no related include members.