### PR TITLE
Add relationship meta object

### DIFF
--- a/drf_jsonapi/relationships.py
+++ b/drf_jsonapi/relationships.py
@@ -184,6 +184,40 @@ class RelationshipHandler:
             }
             return [], meta
 
+    def build_relationship_meta(self, base_serializer, relation, resource, request):
+        """
+        Builds relationship meta for a JSON-API response
+
+        :param RelationshipHandler self: This object
+        :param serializer base_serializer: A model serializer
+        :param string relation: The name of a relationship
+        :param model resource: The model for the relationship "parent"
+        :param django.http.HttpRequest request: The request being processed. May hold information
+                about pagination and/or User object useful for permissions.
+        :return: A meta dictionary
+        :rtype: dict
+        """
+
+        relationship_meta = {}
+
+        # Allow overrides
+        relationship_meta = self.get_relationship_meta(resource, relationship_meta, request)
+
+        return relationship_meta
+
+    def get_relationship_meta(self, resource, relationship_meta, request):
+        """
+        Retrieve meta from given relationship_meta attribute.
+
+        :param RelationshipsHandler self: This object
+        :param QuerySet resource: A model resource
+        :param dict relationship_meta:
+        :return relationship_meta:
+        :rtype: dict
+        """
+
+        return relationship_meta
+
     def add_related(self, resource, related, request):
         """
         Add a related resource.

--- a/drf_jsonapi/relationships.py
+++ b/drf_jsonapi/relationships.py
@@ -205,7 +205,6 @@ class RelationshipHandler:
             resource, relationship_meta, request
         )
 
-
         return relationship_meta
 
     def get_relationship_meta(self, resource, relationship_meta, request):

--- a/drf_jsonapi/relationships.py
+++ b/drf_jsonapi/relationships.py
@@ -201,7 +201,10 @@ class RelationshipHandler:
         relationship_meta = {}
 
         # Allow overrides
-        relationship_meta = self.get_relationship_meta(resource, relationship_meta, request)
+        relationship_meta = self.get_relationship_meta(
+            resource, relationship_meta, request
+        )
+
 
         return relationship_meta
 

--- a/drf_jsonapi/serializers/resources.py
+++ b/drf_jsonapi/serializers/resources.py
@@ -262,6 +262,11 @@ class ResourceSerializer(serializers.Serializer):
         if links:
             data["links"] = links
 
+        # Build relationship meta
+        relationship_meta = handler.build_relationship_meta(self, relation, instance, request)
+        if relationship_meta:
+            data["meta"] = relationship_meta
+
         # If not configured to show data objects, and the relation was not passed as an include, bail here
         if not handler.show_data and relation not in self.include:
             return data

--- a/drf_jsonapi/serializers/resources.py
+++ b/drf_jsonapi/serializers/resources.py
@@ -263,7 +263,9 @@ class ResourceSerializer(serializers.Serializer):
             data["links"] = links
 
         # Build relationship meta
-        relationship_meta = handler.build_relationship_meta(self, relation, instance, request)
+        relationship_meta = handler.build_relationship_meta(
+            self, relation, instance, request
+        )
         if relationship_meta:
             data["meta"] = relationship_meta
 

--- a/drf_jsonapi/viewsets.py
+++ b/drf_jsonapi/viewsets.py
@@ -311,8 +311,6 @@ class ReadOnlyViewSet(
     Create a ViewSet for a read-only endpoint.
     """
 
-    pass
-
 
 class ReadWriteViewSet(
     mixins.ListMixin,
@@ -329,5 +327,3 @@ class ReadWriteViewSet(
     """
     Create a viewset for a readable and writeable endpoint.
     """
-
-    pass

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,8 +15,8 @@ itypes==1.1.0
 jinja2==2.10.1
 markupsafe==1.0
 openapi-codec==1.3.2
-prospector[with_everything]==1.1.6.2
-pylint-django==2.0.2
+prospector[with_everything]==1.1.7
+pylint-django==2.0.10
 pytz==2018.4
 requests==2.22.0
 ruamel.yaml==0.15.37


### PR DESCRIPTION
Added relationship method that allows overrides to include a meta object that contains non-standard meta-information about the relationship.