### PR TITLE
TRAP-3589 Bumps Django to 2.2.28

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.2
+Django==2.2.28
 django-filter==2.0.0  
 djangorestframework==3.9.3
 drf-yasg==1.12.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ chardet==3.0.4
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.5.1
-django==2.2.2
+django==2.2.28
 django-filter==2.0.0
 djangorestframework==3.9.3
 drf-yasg==1.12.1


### PR DESCRIPTION
New patch release for library.

- Bumps django to 2.2.28